### PR TITLE
Fixes/bugs and css

### DIFF
--- a/lib/ui/screens/home_screen/index.dart
+++ b/lib/ui/screens/home_screen/index.dart
@@ -16,13 +16,17 @@ class HomeScreen extends StatelessWidget {
         builder: (context, state) {
           Widget body = Container();
           if (state.activeTab == AppTab.home) {
+            final accountState = BlocProvider.of<AccountBloc>(context).state;
             return Scaffold(
               body: Stack(
                 children: [
                   Column(
                     children: [
                       postsAppBar(context),
-                      Expanded(child: PostsList()),
+                      Expanded(
+                          child: PostsList(
+                        user: (accountState as LoggedIn).user,
+                      )),
                     ],
                   ),
                   if (state.showBackupPhrasePopup) MnemonicBackupPopup(),

--- a/lib/ui/screens/home_screen/widgets/mnemonic_backup_popup/index.dart
+++ b/lib/ui/screens/home_screen/widgets/mnemonic_backup_popup/index.dart
@@ -54,7 +54,7 @@ class MnemonicBackupPopup extends StatelessWidget {
                 ),
                 onPressed: () => _NavigateToShowMnemonicAuthAuth(context),
               ),
-              SecondaryLightInvertRoundedButton(
+              SecondaryDarkButton(
                 padding: EdgeInsets.all(13),
                 child: Text(
                   PostsLocalizations.of(context)

--- a/lib/ui/screens/home_screen/widgets/posts_list/index.dart
+++ b/lib/ui/screens/home_screen/widgets/posts_list/index.dart
@@ -10,6 +10,10 @@ import 'widgets/export.dart';
 /// It simply builds a list using the [ListView.separated] builder
 /// and the [PostListItem] class as the object representing each post.
 class PostsList extends StatefulWidget {
+  final User user;
+
+  const PostsList({Key key, this.user}) : super(key: key);
+
   @override
   _PostsListState createState() => _PostsListState();
 }
@@ -48,7 +52,9 @@ class _PostsListState extends State<PostsList> {
 
           // Hide the refresh indicator
           final state = postsState as PostsLoaded;
-          List<Post> erroredPosts = state.erroredPosts;
+          List<Post> erroredPosts = state.nonErroredPosts
+              .where((post) => post.owner.address == widget.user.address)
+              .toList();
           List<Post> posts = state.nonErroredPosts;
 
           if (!state.refreshing) {

--- a/lib/ui/screens/home_screen/widgets/posts_list/index.dart
+++ b/lib/ui/screens/home_screen/widgets/posts_list/index.dart
@@ -12,7 +12,7 @@ import 'widgets/export.dart';
 class PostsList extends StatefulWidget {
   final User user;
 
-  const PostsList({Key key, this.user}) : super(key: key);
+  const PostsList({Key key, @required this.user}) : super(key: key);
 
   @override
   _PostsListState createState() => _PostsListState();
@@ -52,9 +52,10 @@ class _PostsListState extends State<PostsList> {
 
           // Hide the refresh indicator
           final state = postsState as PostsLoaded;
-          List<Post> erroredPosts = state.nonErroredPosts
+          List<Post> erroredPosts = state.erroredPosts
               .where((post) => post.owner.address == widget.user.address)
               .toList();
+          ;
           List<Post> posts = state.nonErroredPosts;
 
           if (!state.refreshing) {

--- a/lib/ui/screens/home_screen/widgets/posts_list/index.dart
+++ b/lib/ui/screens/home_screen/widgets/posts_list/index.dart
@@ -55,7 +55,6 @@ class _PostsListState extends State<PostsList> {
           List<Post> erroredPosts = state.erroredPosts
               .where((post) => post.owner.address == widget.user.address)
               .toList();
-          ;
           List<Post> posts = state.nonErroredPosts;
 
           if (!state.refreshing) {

--- a/lib/ui/screens/login_screen/widgets/account_created_content/index.dart
+++ b/lib/ui/screens/login_screen/widgets/account_created_content/index.dart
@@ -7,16 +7,25 @@ import 'package:mooncake/ui/ui.dart';
 class AccountCreatedPopupContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final Color textColor = Theme.of(context).brightness == Brightness.light
+        ? Theme.of(context).colorScheme.primary
+        : Colors.white;
     return Column(
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
+        Icon(
+          MooncakeIcons.success,
+          size: 40,
+          color: textColor,
+        ),
+        SizedBox(height: 15),
         Text(
           PostsLocalizations.of(context)
               .translate(Messages.accountCreatedPopupTitleFirstRow)
               .toUpperCase(),
           style: Theme.of(context).textTheme.headline6.copyWith(
-                color: Theme.of(context).colorScheme.primary,
+                color: textColor,
               ),
         ),
         Text(
@@ -24,7 +33,7 @@ class AccountCreatedPopupContent extends StatelessWidget {
               .translate(Messages.accountCreatedPopupTitleSecondRow)
               .toUpperCase(),
           style: Theme.of(context).textTheme.headline6.copyWith(
-                color: Theme.of(context).colorScheme.primary,
+                color: textColor,
               ),
         ),
         SizedBox(height: 10),
@@ -32,10 +41,10 @@ class AccountCreatedPopupContent extends StatelessWidget {
           PostsLocalizations.of(context)
               .translate(Messages.accountCreatedPopupText),
           style: TextStyle(
-            color: Theme.of(context).colorScheme.primary,
+            color: textColor,
           ),
         ),
-        SizedBox(height: 25),
+        SizedBox(height: 15),
         Row(
           children: <Widget>[
             Expanded(

--- a/lib/ui/screens/login_screen/widgets/account_creating_content/index.dart
+++ b/lib/ui/screens/login_screen/widgets/account_creating_content/index.dart
@@ -30,7 +30,7 @@ class CreatingAccountPopupContent extends StatelessWidget {
         SizedBox(height: 30),
         SizedBox(
           width: double.infinity,
-          child: SecondaryLightInvertRoundedButton(
+          child: SecondaryDarkButton(
             child: Text(
               PostsLocalizations.of(context).translate(Messages.cancel),
               textAlign: TextAlign.center,

--- a/lib/ui/screens/login_screen/widgets/login_main_content/index.dart
+++ b/lib/ui/screens/login_screen/widgets/login_main_content/index.dart
@@ -38,7 +38,7 @@ class LoginMainContent extends StatelessWidget {
             margin: EdgeInsets.symmetric(vertical: 4),
             child: SizedBox(
               width: double.infinity,
-              child: SecondaryLightRoundedButton(
+              child: SecondaryLightButton(
                 child: Text(
                   PostsLocalizations.of(context)
                       .translate(Messages.alreadyHaveMnemonicButtonText),
@@ -50,7 +50,7 @@ class LoginMainContent extends StatelessWidget {
           ),
           SizedBox(
             width: double.infinity,
-            child: SecondaryLightRoundedButton(
+            child: SecondaryLightButton(
               child: Text(
                 PostsLocalizations.of(context)
                     .translate(Messages.useMnemonicBackup),

--- a/lib/ui/screens/security_set_biometrics_screen/widgets/set_biometric_body/index.dart
+++ b/lib/ui/screens/security_set_biometrics_screen/widgets/set_biometric_body/index.dart
@@ -43,7 +43,7 @@ class SetBiometricBody extends StatelessWidget {
           Row(
             children: <Widget>[
               Expanded(
-                child: SecondaryLightRoundedButton(
+                child: SecondaryLightButton(
                   child: Text(
                     PostsLocalizations.of(context)
                         .translate(Messages.biometricsUsePasswordButton),

--- a/lib/ui/widgets/bottom_navigation_bar/index.dart
+++ b/lib/ui/widgets/bottom_navigation_bar/index.dart
@@ -12,13 +12,18 @@ class TabSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final Color border = Theme.of(context).brightness == Brightness.light
+        ? Colors.grey[500]
+        : Colors.grey[850];
+
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 5),
       decoration: BoxDecoration(
-          color: Theme.of(context).scaffoldBackgroundColor,
-          border: Border(
-            top: BorderSide(color: Colors.grey[500], width: 0.5),
-          )),
+        color: Theme.of(context).scaffoldBackgroundColor,
+        border: Border(
+          top: BorderSide(color: border, width: 0.5),
+        ),
+      ),
       child: Row(
         mainAxisSize: MainAxisSize.max,
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/lib/ui/widgets/buttons/export.dart
+++ b/lib/ui/widgets/buttons/export.dart
@@ -1,5 +1,5 @@
 export 'check_box_button/index.dart';
 export 'primary_light_button/index.dart';
 export 'primary_button/index.dart';
-export 'secondary_button/index.dart';
-export 'secondary_invert_button/index.dart';
+export 'secondary_light_button/index.dart';
+export 'secondary_dark_button/index.dart';

--- a/lib/ui/widgets/buttons/secondary_dark_button/index.dart
+++ b/lib/ui/widgets/buttons/secondary_dark_button/index.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 
-class SecondaryLightInvertRoundedButton extends StatelessWidget {
+class SecondaryDarkButton extends StatelessWidget {
   final void Function() onPressed;
   final Widget child;
   final double width;
   final EdgeInsets padding;
 
-  const SecondaryLightInvertRoundedButton({
+  const SecondaryDarkButton({
     Key key,
     @required this.onPressed,
     @required this.child,

--- a/lib/ui/widgets/buttons/secondary_light_button/index.dart
+++ b/lib/ui/widgets/buttons/secondary_light_button/index.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 
-class SecondaryLightRoundedButton extends StatelessWidget {
+class SecondaryLightButton extends StatelessWidget {
   final void Function() onPressed;
   final Widget child;
 
-  const SecondaryLightRoundedButton({
+  const SecondaryLightButton({
     Key key,
     @required this.onPressed,
     @required this.child,

--- a/lib/ui/widgets/export_mnemonic_popup/index.dart
+++ b/lib/ui/widgets/export_mnemonic_popup/index.dart
@@ -41,7 +41,7 @@ class ExportMnemonicPopup extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Flexible(
-                    child: SecondaryLightRoundedButton(
+                    child: SecondaryLightButton(
                       onPressed: () => _closePopup(context),
                       child: Text(
                         PostsLocalizations.of(context).translate(

--- a/lib/ui/widgets/export_mnemonic_popup/index.dart
+++ b/lib/ui/widgets/export_mnemonic_popup/index.dart
@@ -36,31 +36,23 @@ class ExportMnemonicPopup extends StatelessWidget {
                 onChanged: (value) => _changeEncryptPassword(context, value),
               ),
               PasswordStrengthIndicator(security: state.passwordSecurity),
-              const SizedBox(height: 16),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Flexible(
-                    child: SecondaryLightButton(
-                      onPressed: () => _closePopup(context),
-                      child: Text(
-                        PostsLocalizations.of(context).translate(
-                            Messages.exportMnemonicDialogCancelButton),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  PrimaryLightButton(
-                    onPressed: state.enableExport
-                        ? () => _exportMnemonic(context)
-                        : null,
-                    child: Text(
-                      PostsLocalizations.of(context)
-                          .translate(Messages.exportMnemonicDialogExportButton),
-                    ),
-                  ),
-                ],
-              )
+              const SizedBox(width: 16),
+              PrimaryButton(
+                enabled: state.enableExport,
+                onPressed:
+                    state.enableExport ? () => _exportMnemonic(context) : null,
+                child: Text(
+                  PostsLocalizations.of(context)
+                      .translate(Messages.exportMnemonicDialogExportButton),
+                ),
+              ),
+              SecondaryDarkButton(
+                onPressed: () => _closePopup(context),
+                child: Text(
+                  PostsLocalizations.of(context)
+                      .translate(Messages.exportMnemonicDialogCancelButton),
+                ),
+              ),
             ],
           ),
         );

--- a/lib/ui/widgets/post_item_header/widgets/post_more_button/widgets/dialogs/widgets/popup_report/index.dart
+++ b/lib/ui/widgets/post_item_header/widgets/post_more_button/widgets/dialogs/widgets/popup_report/index.dart
@@ -98,7 +98,7 @@ class ReportPostPopup extends StatelessWidget {
   }
 
   Widget _blockUserAndReport(BuildContext context, ReportPopupState state) {
-    return SecondaryLightInvertRoundedButton(
+    return SecondaryDarkButton(
       onPressed: () {
         BlocProvider.of<ReportPopupBloc>(context).add(ToggleBlockUser(true));
         _sendReport(context);

--- a/lib/ui/widgets/posts_list_item/widgets/post_actions_bar/widgets/post_likes_counter/index.dart
+++ b/lib/ui/widgets/posts_list_item/widgets/post_actions_bar/widgets/post_likes_counter/index.dart
@@ -57,7 +57,6 @@ class PostLikesCounter extends StatelessWidget {
         Expanded(
           child: Stack(children: [
             Container(
-              // width: iconsWidth,
               height: iconSize,
               child: Stack(
                 children: <Widget>[

--- a/lib/ui/widgets/posts_list_item/widgets/post_actions_bar/widgets/post_likes_counter/index.dart
+++ b/lib/ui/widgets/posts_list_item/widgets/post_actions_bar/widgets/post_likes_counter/index.dart
@@ -15,59 +15,57 @@ class PostLikesCounter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final likes = post.reactions.where((react) => react.isLike).toList();
-    final likesCount = likes.length;
+    final int likesCount = likes.length;
 
-    final double afterIconSize = iconSize * 0.75;
-    double iconsWidth = 0.0;
-    if (likesCount > 0) {
-      iconsWidth += iconSize;
-    }
+    List<Widget> _generateIcons() {
+      List<Widget> finalResults = [];
+      final margin = 15.0;
+      final int count = likesCount > 6 ? 6 : likesCount;
 
-    if (likesCount > 1) {
-      iconsWidth += afterIconSize;
-    }
+      for (var i = 0; i < count; i++) {
+        finalResults.add(
+          Positioned(
+            left: margin * i,
+            child: AccountAvatar(
+              size: iconSize - 2,
+              border: 1,
+              user: likes[i].user,
+            ),
+          ),
+        );
+      }
 
-    if (likesCount > 2) {
-      iconsWidth += afterIconSize;
+      if (likesCount > 6) {
+        finalResults.add(
+          Positioned(
+            left: margin * 6.6,
+            bottom: 0,
+            child: Text(
+              '...',
+              style: TextStyle(fontSize: 13),
+            ),
+          ),
+        );
+      }
+
+      return finalResults;
     }
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.start,
       children: <Widget>[
-        Container(
-          width: iconsWidth,
-          height: iconSize,
-          child: Stack(
-            children: <Widget>[
-              if (likesCount > 2)
-                Positioned(
-                  right: afterIconSize * 2,
-                  child: AccountAvatar(
-                    border: 1,
-                    size: iconSize - 2,
-                    user: likes[2].user,
-                  ),
-                ),
-              if (likesCount > 1)
-                Positioned(
-                  right: afterIconSize,
-                  child: AccountAvatar(
-                    border: 1,
-                    size: iconSize - 2,
-                    user: likes[1].user,
-                  ),
-                ),
-              if (likesCount > 0)
-                Positioned(
-                  right: 0,
-                  child: AccountAvatar(
-                    size: iconSize - 2,
-                    border: 1,
-                    user: likes[0].user,
-                  ),
-                ),
-            ],
-          ),
+        Expanded(
+          child: Stack(children: [
+            Container(
+              // width: iconsWidth,
+              height: iconSize,
+              child: Stack(
+                children: <Widget>[
+                  ..._generateIcons(),
+                ],
+              ),
+            ),
+          ]),
         ),
       ],
     );

--- a/test/entities/posts/post_test.dart
+++ b/test/entities/posts/post_test.dart
@@ -42,7 +42,7 @@ void main() {
     expect(post.images, equals(images));
   });
 
-  test('s', () {
-    expect(stdPost.s.length, 1);
+  test('likes', () {
+    expect(stdPost.likes.length, 1);
   });
 }

--- a/test/entities/posts/post_test.dart
+++ b/test/entities/posts/post_test.dart
@@ -42,7 +42,7 @@ void main() {
     expect(post.images, equals(images));
   });
 
-  test('likes', () {
-    expect(stdPost.likes.length, 1);
+  test('s', () {
+    expect(stdPost.s.length, 1);
   });
 }

--- a/test/ui/screens/home_screen/widgets/mnemonic_backup_popup/index_test.dart
+++ b/test/ui/screens/home_screen/widgets/mnemonic_backup_popup/index_test.dart
@@ -26,7 +26,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(GenericPopup), findsOneWidget);
     expect(find.byType(PrimaryButton), findsOneWidget);
-    expect(find.byType(SecondaryLightInvertRoundedButton), findsOneWidget);
+    expect(find.byType(SecondaryDarkButton), findsOneWidget);
     expect(find.byType(GestureDetector), findsWidgets);
     expect(find.text("mnemonicDoNotShowAgainButton"), findsOneWidget);
   });

--- a/test/ui/screens/home_screen/widgets/posts_list/index_test.dart
+++ b/test/ui/screens/home_screen/widgets/posts_list/index_test.dart
@@ -35,7 +35,9 @@ void main() {
             BlocProvider<PostsListBloc>(create: (_) => mockPostsListBloc),
             BlocProvider<AccountBloc>(create: (_) => mockAccountBloc),
           ],
-          child: PostsList(),
+          child: PostsList(
+            user: userAccount,
+          ),
         ),
       ),
     );
@@ -64,8 +66,12 @@ void main() {
       ),
     );
 
-    Post testErrorPost =
-        testPost.copyWith(status: PostStatus(value: PostStatusValue.ERRORED));
+    Post testErrorPost = testPost.copyWith(
+      status: PostStatus(
+        value: PostStatusValue.ERRORED,
+      ),
+      owner: User.fromAddress("desmos1ew60ztvqxlf5kjjyyzxf7hummlwdadgesu3725"),
+    );
 
     when(mockPostsListBloc.state)
         .thenReturn(PostsLoaded.first(posts: [testErrorPost, ...testPosts]));
@@ -78,7 +84,9 @@ void main() {
             BlocProvider<PostsListBloc>(create: (_) => mockPostsListBloc),
             BlocProvider<AccountBloc>(create: (_) => mockAccountBloc),
           ],
-          child: PostsList(),
+          child: PostsList(
+            user: userAccount,
+          ),
         ),
       ),
     );

--- a/test/ui/screens/login_screen/widgets/account_creating_content/index_test.dart
+++ b/test/ui/screens/login_screen/widgets/account_creating_content/index_test.dart
@@ -26,7 +26,7 @@ void main() {
     await tester.pump(const Duration(seconds: 3));
 
     expect(find.byType(LoadingIndicator), findsOneWidget);
-    expect(find.byType(SecondaryLightInvertRoundedButton), findsOneWidget);
+    expect(find.byType(SecondaryDarkButton), findsOneWidget);
     expect(find.byType(SizedBox), findsWidgets);
     expect(
       find.text(
@@ -39,7 +39,7 @@ void main() {
       findsOneWidget,
     );
 
-    await tester.tap(find.byType(SecondaryLightInvertRoundedButton));
+    await tester.tap(find.byType(SecondaryDarkButton));
     await tester.pump(const Duration(seconds: 3));
     expect(verify(mockAccountBloc.add(LogOut())).callCount, 1);
   });

--- a/test/ui/widgets/buttons/secondary_button/index_test.dart
+++ b/test/ui/widgets/buttons/secondary_button/index_test.dart
@@ -8,7 +8,7 @@ void main() {
       (WidgetTester tester) async {
     await tester.pumpWidget(
       makeTestableWidget(
-        child: SecondaryLightRoundedButton(
+        child: SecondaryLightButton(
           child: Text("pineapples"),
           onPressed: () {},
         ),

--- a/test/ui/widgets/buttons/secondary_invert_button/index_test.dart
+++ b/test/ui/widgets/buttons/secondary_invert_button/index_test.dart
@@ -4,11 +4,11 @@ import 'package:mooncake/ui/ui.dart';
 import '../../../helper.dart';
 
 void main() {
-  testWidgets('SecondaryLightInvertRoundedButton: Displays correctly',
+  testWidgets('SecondaryDarkButton: Displays correctly',
       (WidgetTester tester) async {
     await tester.pumpWidget(
       makeTestableWidget(
-        child: SecondaryLightInvertRoundedButton(
+        child: SecondaryDarkButton(
           child: Text('melons'),
           onPressed: () {},
         ),
@@ -25,12 +25,12 @@ void main() {
     );
   });
 
-  testWidgets('SecondaryLightInvertRoundedButton: Displays correctly Dark',
+  testWidgets('SecondaryDarkButton: Displays correctly Dark',
       (WidgetTester tester) async {
     await tester.pumpWidget(
       makeTestableWidget(
         theme: 'dark',
-        child: SecondaryLightInvertRoundedButton(
+        child: SecondaryDarkButton(
           child: Text('melons'),
           onPressed: () {},
         ),

--- a/test/ui/widgets/export_mnemonic_popup/index_test.dart
+++ b/test/ui/widgets/export_mnemonic_popup/index_test.dart
@@ -31,6 +31,6 @@ void main() {
 
     expect(find.byType(GenericPopup), findsOneWidget);
     expect(find.byType(Column), findsOneWidget);
-    expect(find.byType(SecondaryLightButton), findsOneWidget);
+    expect(find.byType(SecondaryDarkButton), findsOneWidget);
   });
 }

--- a/test/ui/widgets/export_mnemonic_popup/index_test.dart
+++ b/test/ui/widgets/export_mnemonic_popup/index_test.dart
@@ -31,6 +31,6 @@ void main() {
 
     expect(find.byType(GenericPopup), findsOneWidget);
     expect(find.byType(Column), findsOneWidget);
-    expect(find.byType(SecondaryLightRoundedButton), findsOneWidget);
+    expect(find.byType(SecondaryLightButton), findsOneWidget);
   });
 }

--- a/test/ui/widgets/posts_list_item/widgets/post_actions_bar/widgets/post_likes_counter/index_test.dart
+++ b/test/ui/widgets/posts_list_item/widgets/post_actions_bar/widgets/post_likes_counter/index_test.dart
@@ -69,6 +69,6 @@ void main() {
     });
     await tester.pumpAndSettle();
     // should not be more than 3
-    expect(find.byType(AccountAvatar), findsNWidgets(3));
+    expect(find.byType(AccountAvatar), findsNWidgets(4));
   });
 }

--- a/test/ui/widgets/posts_list_item/widgets/post_actions_bar/widgets/post_likes_counter/index_test.dart
+++ b/test/ui/widgets/posts_list_item/widgets/post_actions_bar/widgets/post_likes_counter/index_test.dart
@@ -62,13 +62,29 @@ void main() {
     expect(find.byType(AccountAvatar), findsNWidgets(3));
 
     setStateController(() {
-      reactionTest.add(
-        Reaction(
-            user: userAccount, value: Constants.LIKE_REACTION, code: "123"),
-      );
+      reactionTest.add(Reaction(
+        user: userAccount,
+        value: Constants.LIKE_REACTION,
+        code: "123",
+      ));
+      reactionTest.add(Reaction(
+        user: userAccount,
+        value: Constants.LIKE_REACTION,
+        code: "123",
+      ));
+      reactionTest.add(Reaction(
+        user: userAccount,
+        value: Constants.LIKE_REACTION,
+        code: "123",
+      ));
+      reactionTest.add(Reaction(
+        user: userAccount,
+        value: Constants.LIKE_REACTION,
+        code: "123",
+      ));
     });
     await tester.pumpAndSettle();
-    // should not be more than 3
-    expect(find.byType(AccountAvatar), findsNWidgets(4));
+    expect(find.byType(AccountAvatar), findsNWidgets(6));
+    expect(find.text('...'), findsOneWidget);
   });
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->
Couple of things:
- Renamed the secondary button as there is one with a white border in light mode and primary border in dark mode but there is also a button where light and dark mode would result in a primary border
- Added an extra filter to `erroredPosts` to only display user's own posts. [This is just a just in case]
- And then some ui adjustments
- Went ahead and added the mooncake icon like the wireframe
<img width="250" alt="Screen Shot 2020-08-19 at 11 55 48 AM" src="https://user-images.githubusercontent.com/42913823/90593908-bcef1180-e21b-11ea-9d8d-b93ed80527b1.png">
- Refactored the stack code for likes counter and pushed it up to 6 likes before hiding
<img width="250" alt="Screen Shot 2020-08-19 at 11 40 03 AM" src="https://user-images.githubusercontent.com/42913823/90593925-c5dfe300-e21b-11ea-921d-16b427a06fd8.png">
- Change export mnemonic ui to be more friendly
<img width="386" alt="Screen Shot 2020-08-19 at 10 08 16 AM" src="https://user-images.githubusercontent.com/42913823/90593997-f4f65480-e21b-11ea-8907-5711dd8df817.png">


## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit tests.
- [x] Run flutter format.
- [ ] Updated the documentation.
- [ ] Added an entry to the `CHANGELOG.md` file.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
